### PR TITLE
Highlight two-turn win setup moves in pink

### DIFF
--- a/NumberDuelApp/frmNumberDuel.cs
+++ b/NumberDuelApp/frmNumberDuel.cs
@@ -25,6 +25,7 @@ namespace NumberDuelApp
         Color startcolor = Color.MediumSpringGreen;
         Color usedcolor = Color.Gray;
         Color wincolor = Color.Gold;
+        Color setupwincolor = Color.HotPink;
 
        
         public frmNumberDuel()
@@ -54,6 +55,8 @@ namespace NumberDuelApp
                 b.Enabled = true;
                 b.BackColor = startcolor;
             });
+
+            HighlightTwoTurnWinMoves();
     
 
             DisplayGameStatus();
@@ -71,6 +74,7 @@ namespace NumberDuelApp
             }
           SwitchTurn();
           DisplayGameStatus();
+          HighlightTwoTurnWinMoves();
 
             if (IsComputerTurn())
             {
@@ -236,6 +240,110 @@ namespace NumberDuelApp
             DisplayGameStatus();
             return true;           
             
+        }
+
+        private void HighlightTwoTurnWinMoves()
+        {
+            if (!gameactive)
+            {
+                return;
+            }
+
+            foreach (Button b in lstbuttons)
+            {
+                if (b.Enabled)
+                {
+                    b.BackColor = startcolor;
+                }
+            }
+
+            foreach (Button firstMove in lstbuttons)
+            {
+                if (!firstMove.Enabled)
+                {
+                    continue;
+                }
+
+                int firstNum = int.Parse(firstMove.Text);
+                if (!ValidMove(firstNum))
+                {
+                    continue;
+                }
+
+                if (CanWinOnTurnAfterNext(firstMove, firstNum))
+                {
+                    firstMove.BackColor = setupwincolor;
+                }
+            }
+        }
+
+        private bool CanWinOnTurnAfterNext(Button firstMove, int firstNum)
+        {
+            int originalPrevious = previousnum;
+            previousnum = firstNum;
+
+            var opponentMoves = lstbuttons
+                .Where(b => b.Enabled && b != firstMove && ValidMove(int.Parse(b.Text)))
+                .ToList();
+
+            if (opponentMoves.Count == 0)
+            {
+                previousnum = originalPrevious;
+                return false;
+            }
+
+            foreach (Button opponentMove in opponentMoves)
+            {
+                int opponentNum = int.Parse(opponentMove.Text);
+                previousnum = opponentNum;
+
+                foreach (Button myReply in lstbuttons)
+                {
+                    if (!myReply.Enabled || myReply == firstMove || myReply == opponentMove)
+                    {
+                        continue;
+                    }
+
+                    int replyNum = int.Parse(myReply.Text);
+                    if (!ValidMove(replyNum))
+                    {
+                        continue;
+                    }
+
+                    if (LeavesNoValidMoves(myReply, firstMove, opponentMove, replyNum))
+                    {
+                        previousnum = originalPrevious;
+                        return true;
+                    }
+                }
+            }
+
+            previousnum = originalPrevious;
+            return false;
+        }
+
+        private bool LeavesNoValidMoves(Button replyMove, Button firstMove, Button opponentMove, int replyNum)
+        {
+            int originalPrevious = previousnum;
+            previousnum = replyNum;
+
+            foreach (Button b in lstbuttons)
+            {
+                if (!b.Enabled || b == firstMove || b == opponentMove || b == replyMove)
+                {
+                    continue;
+                }
+
+                int num = int.Parse(b.Text);
+                if (ValidMove(num))
+                {
+                    previousnum = originalPrevious;
+                    return false;
+                }
+            }
+
+            previousnum = originalPrevious;
+            return true;
         }
 
         private void HandleMove(Button btn)

--- a/NumberDuelApp/frmNumberDuel.cs
+++ b/NumberDuelApp/frmNumberDuel.cs
@@ -257,43 +257,66 @@ namespace NumberDuelApp
                 }
             }
 
-            var remainingOptions = lstbuttons
-                .Where(b => b.Enabled)
+            var validMoves = lstbuttons
+                .Where(b => b.Enabled && ValidMove(int.Parse(b.Text)))
                 .ToList();
 
-            if (remainingOptions.Count != 2)
+            if (validMoves.Count != 1)
             {
                 return;
             }
 
-            if (remainingOptions.Any(b => !ValidMove(int.Parse(b.Text))))
+            Button forcedMove = validMoves[0];
+            if (int.Parse(forcedMove.Text) != 1)
             {
                 return;
             }
 
-            Button? oneButton = remainingOptions.FirstOrDefault(b => int.Parse(b.Text) == 1);
-            if (oneButton == null)
+            var finishingMoves = GetImmediateFinishingMovesAfterForcedOne(forcedMove);
+            if (finishingMoves.Count > 0)
             {
-                return;
-            }
-
-            Button otherButton = remainingOptions.First(b => b != oneButton);
-
-            if (EndsGameImmediately(otherButton))
-            {
-                oneButton.BackColor = setupwincolor;
-                otherButton.BackColor = setupwincolor;
+                forcedMove.BackColor = setupwincolor;
+                finishingMoves.ForEach(b => b.BackColor = setupwincolor);
             }
         }
 
-        private bool EndsGameImmediately(Button selectedMove)
+        private List<Button> GetImmediateFinishingMovesAfterForcedOne(Button forcedOne)
+        {
+            int originalPrevious = previousnum;
+            previousnum = 1;
+            List<Button> finishingMoves = new();
+
+            foreach (Button b in lstbuttons)
+            {
+                if (!b.Enabled || b == forcedOne)
+                {
+                    continue;
+                }
+
+                int candidateNum = int.Parse(b.Text);
+                if (!ValidMove(candidateNum))
+                {
+                    continue;
+                }
+
+                if (EndsGameImmediatelyAfterChoice(b, forcedOne))
+                {
+                    finishingMoves.Add(b);
+                }
+            }
+
+            previousnum = originalPrevious;
+            return finishingMoves;
+        }
+
+        private bool EndsGameImmediatelyAfterChoice(Button selectedMove, Button forcedOne)
         {
             int originalPrevious = previousnum;
             previousnum = int.Parse(selectedMove.Text);
 
             foreach (Button b in lstbuttons)
             {
-                if (!b.Enabled || b == selectedMove)
+                if (!b.Enabled || b == forcedOne || b == selectedMove)
                 {
                     continue;
                 }

--- a/NumberDuelApp/frmNumberDuel.cs
+++ b/NumberDuelApp/frmNumberDuel.cs
@@ -25,7 +25,7 @@ namespace NumberDuelApp
         Color startcolor = Color.MediumSpringGreen;
         Color usedcolor = Color.Gray;
         Color wincolor = Color.Gold;
-        Color setupwincolor = Color.HotPink;
+        Color setupwincolor = Color.Pink;
 
        
         public frmNumberDuel()
@@ -56,7 +56,7 @@ namespace NumberDuelApp
                 b.BackColor = startcolor;
             });
 
-            HighlightTwoTurnWinMoves();
+            HighlightOneAndFinisherMoves();
     
 
             DisplayGameStatus();
@@ -74,7 +74,7 @@ namespace NumberDuelApp
             }
           SwitchTurn();
           DisplayGameStatus();
-          HighlightTwoTurnWinMoves();
+          HighlightOneAndFinisherMoves();
 
             if (IsComputerTurn())
             {
@@ -242,7 +242,7 @@ namespace NumberDuelApp
             
         }
 
-        private void HighlightTwoTurnWinMoves()
+        private void HighlightOneAndFinisherMoves()
         {
             if (!gameactive)
             {
@@ -257,85 +257,43 @@ namespace NumberDuelApp
                 }
             }
 
-            foreach (Button firstMove in lstbuttons)
-            {
-                if (!firstMove.Enabled)
-                {
-                    continue;
-                }
-
-                int firstNum = int.Parse(firstMove.Text);
-                if (!ValidMove(firstNum))
-                {
-                    continue;
-                }
-
-                if (CanWinOnTurnAfterNext(firstMove, firstNum))
-                {
-                    firstMove.BackColor = setupwincolor;
-                }
-            }
-        }
-
-        private bool CanWinOnTurnAfterNext(Button firstMove, int firstNum)
-        {
-            int originalPrevious = previousnum;
-            previousnum = firstNum;
-
-            var opponentMoves = lstbuttons
-                .Where(b => b.Enabled && b != firstMove && ValidMove(int.Parse(b.Text)))
+            var validMoves = lstbuttons
+                .Where(b => b.Enabled && ValidMove(int.Parse(b.Text)))
                 .ToList();
 
-            if (opponentMoves.Count == 0)
+            if (validMoves.Count != 2)
             {
-                previousnum = originalPrevious;
-                return false;
+                return;
             }
 
-            foreach (Button opponentMove in opponentMoves)
+            Button? oneButton = validMoves.FirstOrDefault(b => int.Parse(b.Text) == 1);
+            if (oneButton == null)
             {
-                int opponentNum = int.Parse(opponentMove.Text);
-                previousnum = opponentNum;
-
-                foreach (Button myReply in lstbuttons)
-                {
-                    if (!myReply.Enabled || myReply == firstMove || myReply == opponentMove)
-                    {
-                        continue;
-                    }
-
-                    int replyNum = int.Parse(myReply.Text);
-                    if (!ValidMove(replyNum))
-                    {
-                        continue;
-                    }
-
-                    if (LeavesNoValidMoves(myReply, firstMove, opponentMove, replyNum))
-                    {
-                        previousnum = originalPrevious;
-                        return true;
-                    }
-                }
+                return;
             }
 
-            previousnum = originalPrevious;
-            return false;
+            Button otherButton = validMoves.First(b => b != oneButton);
+
+            if (EndsGameImmediately(otherButton))
+            {
+                oneButton.BackColor = setupwincolor;
+                otherButton.BackColor = setupwincolor;
+            }
         }
 
-        private bool LeavesNoValidMoves(Button replyMove, Button firstMove, Button opponentMove, int replyNum)
+        private bool EndsGameImmediately(Button selectedMove)
         {
             int originalPrevious = previousnum;
-            previousnum = replyNum;
+            previousnum = int.Parse(selectedMove.Text);
 
             foreach (Button b in lstbuttons)
             {
-                if (!b.Enabled || b == firstMove || b == opponentMove || b == replyMove)
+                if (!b.Enabled || b == selectedMove)
                 {
                     continue;
                 }
 
-                int num = int.Parse(b.Text);
-                if (ValidMove(num))
+                if (ValidMove(int.Parse(b.Text)))
                 {
                     previousnum = originalPrevious;
                     return false;

--- a/NumberDuelApp/frmNumberDuel.cs
+++ b/NumberDuelApp/frmNumberDuel.cs
@@ -257,22 +257,27 @@ namespace NumberDuelApp
                 }
             }
 
-            var validMoves = lstbuttons
-                .Where(b => b.Enabled && ValidMove(int.Parse(b.Text)))
+            var remainingOptions = lstbuttons
+                .Where(b => b.Enabled)
                 .ToList();
 
-            if (validMoves.Count != 2)
+            if (remainingOptions.Count != 2)
             {
                 return;
             }
 
-            Button? oneButton = validMoves.FirstOrDefault(b => int.Parse(b.Text) == 1);
+            if (remainingOptions.Any(b => !ValidMove(int.Parse(b.Text))))
+            {
+                return;
+            }
+
+            Button? oneButton = remainingOptions.FirstOrDefault(b => int.Parse(b.Text) == 1);
             if (oneButton == null)
             {
                 return;
             }
 
-            Button otherButton = validMoves.First(b => b != oneButton);
+            Button otherButton = remainingOptions.First(b => b != oneButton);
 
             if (EndsGameImmediately(otherButton))
             {

--- a/NumberDuelApp/frmNumberDuel.cs
+++ b/NumberDuelApp/frmNumberDuel.cs
@@ -19,6 +19,7 @@ namespace NumberDuelApp
         TurnEnum winner;
 
         List<Button> lstbuttons;
+        HashSet<Button> pinkbuttons = new();
         bool gameactive = false;
         int previousnum = 0;
         bool playcomputer = false;
@@ -55,6 +56,7 @@ namespace NumberDuelApp
                 b.Enabled = true;
                 b.BackColor = startcolor;
             });
+            pinkbuttons.Clear();
 
             HighlightOneAndFinisherMoves();
     
@@ -249,12 +251,9 @@ namespace NumberDuelApp
                 return;
             }
 
-            foreach (Button b in lstbuttons)
+            foreach (Button b in lstbuttons.Where(b => b.Enabled))
             {
-                if (b.Enabled)
-                {
-                    b.BackColor = startcolor;
-                }
+                b.BackColor = pinkbuttons.Contains(b) ? setupwincolor : startcolor;
             }
 
             var validMoves = lstbuttons
@@ -275,8 +274,13 @@ namespace NumberDuelApp
             var finishingMoves = GetImmediateFinishingMovesAfterForcedOne(forcedMove);
             if (finishingMoves.Count > 0)
             {
-                forcedMove.BackColor = setupwincolor;
-                finishingMoves.ForEach(b => b.BackColor = setupwincolor);
+                pinkbuttons.Add(forcedMove);
+                finishingMoves.ForEach(b => pinkbuttons.Add(b));
+
+                foreach (Button b in lstbuttons.Where(b => b.Enabled && pinkbuttons.Contains(b)))
+                {
+                    b.BackColor = setupwincolor;
+                }
             }
         }
 
@@ -343,6 +347,7 @@ namespace NumberDuelApp
             previousnum = num;
             lblNumPicked.Text = "Number: " + btn.Text;
             btn.Enabled = false;
+            pinkbuttons.Remove(btn);
             btn.BackColor = usedcolor;
 
             DoTurn();


### PR DESCRIPTION
### Motivation

- Provide a visual hint for moves that set up a forced win on the player’s turn after next (e.g. pick 1 then 11), improving game UX by highlighting those candidate buttons. 
- Ensure the hint updates as the board changes so players always see current two-turn win opportunities.

### Description

- Added a new color field `setupwincolor = Color.HotPink` and reset enabled buttons to `startcolor` before computing hints in `frmNumberDuel`. 
- Recompute highlights at game start and after each turn switch by calling `HighlightTwoTurnWinMoves()` from `StartGame()` and `DoTurn()`. 
- Implemented `HighlightTwoTurnWinMoves()`, `CanWinOnTurnAfterNext(...)`, and `LeavesNoValidMoves(...)` to simulate a candidate move, opponent responses, and replies that leave zero legal moves and mark candidate buttons pink when a two-turn forced win exists. 
- Changes applied to `NumberDuelApp/frmNumberDuel.cs` and preserve/restore `previousnum` while simulating moves to avoid mutating game state.

### Testing

- Attempted to run `dotnet build NumberDuelApp/NumberDuelApp.csproj`, but the build could not be executed because the `dotnet` CLI is not available in this environment (build failed). 
- No other automated tests were available or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69c4657f899083249f81166125d75d16)